### PR TITLE
Updating the PointParser to no longer throw a null pointer exception …

### DIFF
--- a/src/main/java/com/bedatadriven/jackson/datatype/jts/parsers/PointParser.java
+++ b/src/main/java/com/bedatadriven/jackson/datatype/jts/parsers/PointParser.java
@@ -18,7 +18,7 @@ public class PointParser extends BaseParser implements GeometryParser<Point> {
     }
 
     public static Coordinate coordinateFromJson(JsonNode array) {
-        assert array.isArray() && (array.size() == 2 || array.size() == 3) : "expecting coordinate array with single point [ x, y, |z| ]";
+        assert array != null && array.isArray() && (array.size() == 2 || array.size() == 3) : "expecting coordinate array with single point [ x, y, |z| ]";
 
         if (array.size() == 2) {
             return new Coordinate(

--- a/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
+++ b/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertThat;
 public abstract class BaseJtsModuleTest<T extends Geometry> {
     protected GeometryFactory gf = new GeometryFactory();
     private ObjectWriter writer;
-    private ObjectMapper mapper;
+    protected ObjectMapper mapper;
     private T geometry;
     private String geometryAsGeoJson;
 

--- a/src/test/java/com/bedatadriven/jackson/datatype/jts/PointTest.java
+++ b/src/test/java/com/bedatadriven/jackson/datatype/jts/PointTest.java
@@ -1,11 +1,9 @@
 package com.bedatadriven.jackson.datatype.jts;
 
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
 
 /**
  * Created by mihaildoronin on 11/11/15.
@@ -25,5 +23,17 @@ public class PointTest extends BaseJtsModuleTest<Point> {
     protected Point createGeometry() {
         return gf.createPoint(new Coordinate(1.2345678, 2.3456789));
     }
-
+    
+    /**
+     * Expectation that a malformed json tree node will perform an assertion of not null rather
+     * than an unexpected {@link NullPointerException} being thrown.
+     * @throws Exception
+     */
+    @Test(expected = AssertionError.class)
+    public void shouldThrowDeserializeConcreteType() throws Exception {
+    	
+        // This malformed value has a typo of: 'cordinates'
+        String malformedSerializedPoint = "{\"type\":\"Point\",\"cordinates\":[1.2345678,2.3456789]}";
+        this.mapper.readValue(malformedSerializedPoint, getType());
+    }
 }


### PR DESCRIPTION
…and rather an assertion error if the "coordinates" json path is unable to be retrieved from the parent node.